### PR TITLE
Update AzDO build to 1ES pool

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
 queue:
-  name: MicroBuildV2Pool
+  name: VSEngSS-MicroBuild2019-1ES
   timeoutInMinutes: 120
   demands:
   - msbuild

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,8 @@ pr:
       - CONTRIBUTING.md
       - README.md
 
-pool: VSEngSS-MicroBuild2019-1ES
+pool:
+  vmImage: vs2017-win2016
 
 variables:
   BuildConfiguration: Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ pr:
       - CONTRIBUTING.md
       - README.md
 
-pool: VSEngSS-MicroBuild2017
+pool: VSEngSS-MicroBuild2019-1ES
 
 variables:
   BuildConfiguration: Release


### PR DESCRIPTION
Self-Hosted pools are being deprecated in favor of 1ES pools.