### PR TITLE
Update cert to valid SHA2 cert

### DIFF
--- a/src/VSIXBootstrapper/VSIXBootstrapper.vcxproj
+++ b/src/VSIXBootstrapper/VSIXBootstrapper.vcxproj
@@ -109,7 +109,7 @@
   </ItemGroup>
   <ItemGroup>
     <FilesToSign Include="$(TargetPath)">
-      <Authenticode>Microsoft</Authenticode>
+      <Authenticode>Microsoft400</Authenticode>
       <Visible>false</Visible>
     </FilesToSign>
   </ItemGroup>


### PR DESCRIPTION
The Microsoft SHA1 cert is no longer supported. The recommended cert for the old Microsoft one is Microsoft400.