### PR TITLE
Add compliance build and update minimum supported OS to Windows 7

### DIFF
--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -1,0 +1,64 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+queue:
+  name: VSEngSS-MicroBuild2019-1ES
+  timeoutInMinutes: 120
+  demands:
+  - msbuild
+  - visualstudio
+  - vstest
+
+steps:
+- template: inc/build.yml
+  parameters:
+      BuildConfiguration: $(BuildConfiguration)
+      BuildPlatform: $(BuildPlatform)
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: Detect components
+  inputs:
+    sourceScanPath: $(Build.SourcesDirectory)
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-prefast.SDLNativeRules@2
+  displayName: 'Run the PREfast SDL Native Rules for MSBuild'
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+  displayName: 'Run PoliCheck'
+  inputs:
+    targetType: F
+    targetArgument: '$(Build.SourcesDirectory)'
+    optionsFC: 0
+    optionsXS: 1
+    optionsHMENABLE: 0
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
+  displayName: 'Run BinSkim'
+  inputs:
+    InputType: Basic
+    Function: analyze
+    AnalyzeTarget: 'bin\$(BuildConfiguration)\*.exe'
+    AnalyzeSymPath: 'bin\$(BuildConfiguration)'
+    AnalyzeVerbose: true
+    AnalyzeHashes: true
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  displayName: 'Run CredScan'
+  inputs:
+    debugMode: false
+
+# Publish compliance results
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  displayName: 'Publish Security Analysis Logs'
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  displayName: Check SDL results
+  inputs:
+    AllTools: true
+
+- task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+  displayName: Clean up
+  condition: succeededOrFailed()

--- a/src/VSIXBootstrapper.Shared/CoInitializer.h
+++ b/src/VSIXBootstrapper.Shared/CoInitializer.h
@@ -7,7 +7,7 @@
 
 struct CoInitializerTraits
 {
-    static HRESULT __cdecl CoInitialize(_In_ LPVOID)
+    static HRESULT __cdecl CoInitialize(_In_opt_ LPVOID)
     {
         return ::CoInitialize(NULL);
     }

--- a/src/VSIXBootstrapper/VSIXBootstrapper.vcxproj
+++ b/src/VSIXBootstrapper/VSIXBootstrapper.vcxproj
@@ -61,6 +61,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -78,6 +79,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/VSIXBootstrapper/VSIXBootstrapper.vcxproj
+++ b/src/VSIXBootstrapper/VSIXBootstrapper.vcxproj
@@ -16,7 +16,7 @@
     <ProjectGuid>{22FFC1AB-F3E2-4379-B26E-67D67E2A1067}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>VSIXBootstrapper</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="..\..\inc\Common.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/VSIXBootstrapper/VSIXBootstrapper.vcxproj
+++ b/src/VSIXBootstrapper/VSIXBootstrapper.vcxproj
@@ -23,13 +23,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/VSIXBootstrapper/targetver.h
+++ b/src/VSIXBootstrapper/targetver.h
@@ -11,6 +11,6 @@
 #undef  _WIN32_WINNT
 #endif
 
-#define _WIN32_WINNT 0x0500
+#define _WIN32_WINNT 0x601
 
 #include <SDKDDKVer.h>

--- a/test/VSIXBootstrapper.Test/CoInitializerTests.cpp
+++ b/test/VSIXBootstrapper.Test/CoInitializerTests.cpp
@@ -14,7 +14,7 @@ public:
     {
         struct TestTraits
         {
-            static HRESULT __cdecl CoInitialize(_In_ LPVOID)
+            static HRESULT __cdecl CoInitialize(_In_opt_ LPVOID)
             {
                 return E_FAIL;
             }
@@ -33,7 +33,7 @@ public:
         static byte count = 0;
         struct TestTraits
         {
-            static HRESULT __stdcall CoInitialize(_In_ LPVOID)
+            static HRESULT __stdcall CoInitialize(_In_opt_ LPVOID)
             {
                 count++;
                 return S_OK;

--- a/test/VSIXBootstrapper.Test/ProcessTests.cpp
+++ b/test/VSIXBootstrapper.Test/ProcessTests.cpp
@@ -28,7 +28,6 @@ public:
             )
             {
                 Assert::AreEqual(L"\"C:\\ShouldNotExist.exe\" ignored", lpCommandLine);
-
                 return FALSE;
             }
 

--- a/test/VSIXBootstrapper.Test/RegistryKeyTests.cpp
+++ b/test/VSIXBootstrapper.Test/RegistryKeyTests.cpp
@@ -122,9 +122,11 @@ public:
                 Assert::AreEqual(L"Value", lpValueName);
 
                 Assert::IsNotNull(lpType);
+                #pragma warning(suppress: 6011) // Assert ensures this isn't null
                 *lpType = REG_DWORD;
 
                 Assert::IsNotNull(lpcbData);
+                #pragma warning(suppress: 6011) // Assert ensures this isn't null
                 *lpcbData = 0;
 
                 return ERROR_SUCCESS;
@@ -183,7 +185,10 @@ public:
                 }
 
                 auto cch = wcslen(wsz);
-                *lpcbData = ++cch * sizeof(WCHAR);
+                if (lpcbData)
+                {
+                    *lpcbData = ++cch * sizeof(WCHAR);
+                }
 
                 if (lpData)
                 {

--- a/test/VSIXBootstrapper.Test/RegistryKeyTests.cpp
+++ b/test/VSIXBootstrapper.Test/RegistryKeyTests.cpp
@@ -192,6 +192,7 @@ public:
 
                 if (lpData)
                 {
+                    #pragma warning(suppress: 6386) // Static analysis is failing to recognize proper buffer size
                     wcscpy_s((LPWSTR)lpData, cch, wsz);
                 }
 

--- a/test/VSIXBootstrapper.Test/ResourcesTests.cpp
+++ b/test/VSIXBootstrapper.Test/ResourcesTests.cpp
@@ -14,6 +14,7 @@ public:
     {
         struct TestTraits
         {
+            #pragma warning(suppress: 6054) // Unexpected, so ignore that lpBuffer is not set
             static int ResourcesGetString(__in_opt HINSTANCE hInstance, __in UINT nID, __out_ecount_part(cchBufferMax, return +1) LPWSTR lpBuffer, __in int cchBufferMax)
             {
                 return 0;
@@ -47,6 +48,7 @@ private:
 
     struct TestStringTraits
     {
+        #pragma warning(suppress: 6054) // Static analysis is failing to detect that m_wsz will be null-terminated
         static int ResourcesGetString(__in_opt HINSTANCE hInstance, __in UINT nID, __out_ecount_part(cchBufferMax, return +1) LPWSTR lpBuffer, __in int cchBufferMax)
         {
             ::memcpy(lpBuffer, &m_wsz, sizeof(LPWSTR));

--- a/test/VSIXBootstrapper.Test/VSIXBootstrapper.Test.vcxproj
+++ b/test/VSIXBootstrapper.Test/VSIXBootstrapper.Test.vcxproj
@@ -16,7 +16,7 @@
     <ProjectGuid>{EEADDAC3-DDD5-4A28-BB13-B3B76682C1E1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>VSIXBootstrapper</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="..\..\inc\Common.props" />

--- a/test/VSIXBootstrapper.Test/VSIXBootstrapper.Test.vcxproj
+++ b/test/VSIXBootstrapper.Test/VSIXBootstrapper.Test.vcxproj
@@ -24,14 +24,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>

--- a/test/VSIXBootstrapper.Test/VSIXBootstrapperTests.cpp
+++ b/test/VSIXBootstrapper.Test/VSIXBootstrapperTests.cpp
@@ -32,6 +32,7 @@ public:
 
         struct TestResourcesTraits
         {
+            #pragma warning(suppress: 6054) // Unreachable code, ignore the fact we didn't fill lpBuffer
             static int __cdecl ResourcesGetString(__in_opt HINSTANCE hInstance, __in UINT nID, __out_ecount_part(cchBufferMax, return +1) LPWSTR lpBuffer, __in int cchBufferMax)
             {
                 Assert::Fail(L"Unexpected");
@@ -67,6 +68,8 @@ public:
 
         struct TestResourcesTraits
         {
+            #pragma warning(suppress: 6054) // Unreachable code, ignore the fact we didn't fill lpBuffer
+            #pragma warning(suppress: 6385) // Static analysis is failing to recognize proper buffer size
             static int __cdecl ResourcesGetString(__in_opt HINSTANCE hInstance, __in UINT nID, __out_ecount_part(cchBufferMax, return +1) LPWSTR lpBuffer, __in int cchBufferMax)
             {
                 if (IDS_CAPTION == nID)
@@ -87,6 +90,8 @@ public:
                     ::memcpy(lpBuffer, &wsz, sizeof(LPWSTR));
                     return wcslen(wsz);
                 }
+
+                Assert::Fail(L"Unexpected");
 
                 return 0;
             }
@@ -177,6 +182,7 @@ public:
 
                 if (lpData)
                 {
+                    #pragma warning(suppress: 6386) // Static analysis is failing to recognize proper buffer size
                     wcscpy_s((LPWSTR)lpData, cch, wsz);
                 }
 
@@ -330,6 +336,7 @@ public:
 
                 if (lpData)
                 {
+                    #pragma warning(suppress: 6386) // Static analysis is failing to recognize proper buffer size
                     wcscpy_s((LPWSTR)lpData, cch, wsz);
                 }
 
@@ -490,6 +497,8 @@ public:
 
         struct TestResourcesTraits
         {
+            #pragma warning(suppress: 6054) // Unreachable code, ignore the fact we didn't fill lpBuffer
+            #pragma warning(suppress: 6385) // Static analysis is failing to recognize proper buffer size
             static int ResourcesGetString(__in_opt HINSTANCE hInstance, __in UINT nID, __out_ecount_part(cchBufferMax, return +1) LPWSTR lpBuffer, __in int cchBufferMax)
             {
                 if (IDS_CAPTION == nID)
@@ -602,6 +611,8 @@ public:
 
         struct TestResourcesTraits
         {
+            #pragma warning(suppress: 6054) // Unreachable code, ignore the fact we didn't fill lpBuffer
+            #pragma warning(suppress: 6385) // Static analysis is failing to recognize proper buffer size
             static int ResourcesGetString(__in_opt HINSTANCE hInstance, __in UINT nID, __out_ecount_part(cchBufferMax, return +1) LPWSTR lpBuffer, __in int cchBufferMax)
             {
                 if (IDS_CAPTION == nID)

--- a/test/VSIXBootstrapper.Test/VSIXBootstrapperTests.cpp
+++ b/test/VSIXBootstrapper.Test/VSIXBootstrapperTests.cpp
@@ -104,7 +104,7 @@ public:
     {
         struct TestCoInitializerTraits
         {
-            static HRESULT __cdecl CoInitialize(_In_ LPVOID)
+            static HRESULT __cdecl CoInitialize(_In_opt_ LPVOID)
             {
                 s_count++;
 
@@ -170,7 +170,10 @@ public:
                 }
 
                 auto cch = wcslen(wsz);
-                *lpcbData = ++cch * sizeof(WCHAR);
+                if (lpcbData)
+                {
+                    *lpcbData = ++cch * sizeof(WCHAR);
+                }
 
                 if (lpData)
                 {
@@ -254,7 +257,7 @@ public:
     {
         struct TestCoInitializerTraits
         {
-            static HRESULT __cdecl CoInitialize(_In_ LPVOID)
+            static HRESULT __cdecl CoInitialize(_In_opt_ LPVOID)
             {
                 s_count++;
 
@@ -320,7 +323,10 @@ public:
                 }
 
                 auto cch = wcslen(wsz);
-                *lpcbData = ++cch * sizeof(WCHAR);
+                if (lpcbData)
+                {
+                    *lpcbData = ++cch * sizeof(WCHAR);
+                }
 
                 if (lpData)
                 {
@@ -404,7 +410,7 @@ public:
     {
         struct TestCoInitializerTraits
         {
-            static HRESULT __cdecl CoInitialize(_In_ LPVOID)
+            static HRESULT __cdecl CoInitialize(_In_opt_ LPVOID)
             {
                 s_count++;
 
@@ -519,7 +525,7 @@ public:
     {
         struct TestCoInitializerTraits
         {
-            static HRESULT __cdecl CoInitialize(_In_ LPVOID)
+            static HRESULT __cdecl CoInitialize(_In_opt_ LPVOID)
             {
                 s_count++;
 

--- a/test/VSIXBootstrapper.Test/stdafx.h
+++ b/test/VSIXBootstrapper.Test/stdafx.h
@@ -17,7 +17,4 @@
 
 // Disable Prefast warnings
 #pragma warning(disable: 6101) // Returning uninitialied data. This is from test cases that fail if the code executes.
-#pragma warning(disable: 6054) // Buffer may not be null-terminated.
-#pragma warning(disable: 6385) // Reading extra data
-#pragma warning(disable: 6386) // Potential buffer overrun.
-#pragma warning(disable: 6387) // Potential input not matching expected.
+#pragma warning(disable: 6387) // Potential input not matching expected from SAL annotation. Tests don't always match SAL for expected fall-through cases.

--- a/test/VSIXBootstrapper.Test/stdafx.h
+++ b/test/VSIXBootstrapper.Test/stdafx.h
@@ -14,3 +14,10 @@
 #include "CppUnitTest.h"
 
 // Project header files
+
+// Disable Prefast warnings
+#pragma warning(disable: 6101) // Returning uninitialied data. This is from test cases that fail if the code executes.
+#pragma warning(disable: 6054) // Buffer may not be null-terminated.
+#pragma warning(disable: 6385) // Reading extra data
+#pragma warning(disable: 6386) // Potential buffer overrun.
+#pragma warning(disable: 6387) // Potential input not matching expected.

--- a/test/VSIXBootstrapper.Test/targetver.h
+++ b/test/VSIXBootstrapper.Test/targetver.h
@@ -11,6 +11,6 @@
 #undef  _WIN32_WINNT
 #endif
 
-#define _WIN32_WINNT 0x0500
+#define _WIN32_WINNT 0x601
 
 #include <SDKDDKVer.h>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "assemblyVersion": "1.0",
     "publicReleaseRefSpec": [
         "^refs/heads/master$",


### PR DESCRIPTION
To make the repo compliant, a set of compliance tasks needs to be run. This adds the compliance tasks, fixes the errors in the source, and disables some warnings in the test project.

The Prefast compliance task doesn't support Windows XP, so we need to update the targeting to Windows 7.