### PR TITLE
Turn off TSA onboarding in CI build

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -17,6 +17,7 @@ extends:
       tsa:
         enabled: true
         configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
+        onboard: false # No need to onboard since we have previously
       policheck:
         enabled: true
       binskim:


### PR DESCRIPTION
Turn off TSA onboarding in CI build. The config file does not contain the needed info to properly onboard so it will report a warning in the build.