### PR TITLE
Revert to windows-2019 image to use VC 141

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ pr:
       - README.md
 
 pool:
-  vmImage: windows-2022
+  vmImage: windows-2019
 
 variables:
   BuildConfiguration: Release


### PR DESCRIPTION
We require the VC 141 toolset and the windows-2022 image just removed that toolset from the image. To fix our PR builds, we will need to stick to the windows-2019 pool until we update our VC version.