### PR TITLE
Disable c26444 warning for lambda in test file

### DIFF
--- a/test/VSIXBootstrapper.Test/CoInitializerTests.cpp
+++ b/test/VSIXBootstrapper.Test/CoInitializerTests.cpp
@@ -25,10 +25,10 @@ public:
             }
         };
 
-        #pragma warning(push)
-        #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
+    #pragma warning(push)
+    #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
         Assert::ExpectException<win32_error>([]() { CoInitializer<TestTraits>(); });
-        #pragma warning(pop)
+    #pragma warning(pop)
     }
 
     TEST_METHOD(CoInitializer_Unitializes)

--- a/test/VSIXBootstrapper.Test/CoInitializerTests.cpp
+++ b/test/VSIXBootstrapper.Test/CoInitializerTests.cpp
@@ -25,7 +25,10 @@ public:
             }
         };
 
+        #pragma warning(push)
+        #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
         Assert::ExpectException<win32_error>([]() { CoInitializer<TestTraits>(); });
+        #pragma warning(pop)
     }
 
     TEST_METHOD(CoInitializer_Unitializes)

--- a/test/VSIXBootstrapper.Test/ProcessTests.cpp
+++ b/test/VSIXBootstrapper.Test/ProcessTests.cpp
@@ -39,10 +39,10 @@ public:
             }
         };
 
-        #pragma warning(push)
-        #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
+    #pragma warning(push)
+    #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
         Assert::ExpectException<win32_error>([]() { Process<TestTraits>(SW_NORMAL, L"C:\\ShouldNotExist.exe", L"ignored"); });
-        #pragma warning(pop)
+    #pragma warning(pop)
     }
 
     TEST_METHOD(Process_Wait)

--- a/test/VSIXBootstrapper.Test/ProcessTests.cpp
+++ b/test/VSIXBootstrapper.Test/ProcessTests.cpp
@@ -39,7 +39,10 @@ public:
             }
         };
 
+        #pragma warning(push)
+        #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
         Assert::ExpectException<win32_error>([]() { Process<TestTraits>(SW_NORMAL, L"C:\\ShouldNotExist.exe", L"ignored"); });
+        #pragma warning(pop)
     }
 
     TEST_METHOD(Process_Wait)

--- a/test/VSIXBootstrapper.Test/RegistryKeyTests.cpp
+++ b/test/VSIXBootstrapper.Test/RegistryKeyTests.cpp
@@ -38,10 +38,10 @@ public:
             }
         };
 
-        #pragma warning(push)
-        #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
+    #pragma warning(push)
+    #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
         Assert::ExpectException<win32_error>([]() { RegistryKey<TestTraits>(HKEY_LOCAL_MACHINE, L"ShouldNotExist"); });
-        #pragma warning(pop)
+    #pragma warning(pop)
     }
 
     TEST_METHOD(RegistryKey_Value_Missing_Throws)

--- a/test/VSIXBootstrapper.Test/RegistryKeyTests.cpp
+++ b/test/VSIXBootstrapper.Test/RegistryKeyTests.cpp
@@ -38,7 +38,10 @@ public:
             }
         };
 
+        #pragma warning(push)
+        #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
         Assert::ExpectException<win32_error>([]() { RegistryKey<TestTraits>(HKEY_LOCAL_MACHINE, L"ShouldNotExist"); });
+        #pragma warning(pop)
     }
 
     TEST_METHOD(RegistryKey_Value_Missing_Throws)

--- a/test/VSIXBootstrapper.Test/ResourcesTests.cpp
+++ b/test/VSIXBootstrapper.Test/ResourcesTests.cpp
@@ -23,10 +23,10 @@ public:
 
         Resources<TestTraits> sut(NULL);
         
-        #pragma warning(push)
-        #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
+    #pragma warning(push)
+    #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
         Assert::ExpectException<win32_error>([&]() { sut.GetString(0); });
-        #pragma warning(pop)
+    #pragma warning(pop)
     }
 
     TEST_METHOD(Resources_FormatString)

--- a/test/VSIXBootstrapper.Test/ResourcesTests.cpp
+++ b/test/VSIXBootstrapper.Test/ResourcesTests.cpp
@@ -22,7 +22,11 @@ public:
         };
 
         Resources<TestTraits> sut(NULL);
+        
+        #pragma warning(push)
+        #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
         Assert::ExpectException<win32_error>([&]() { sut.GetString(0); });
+        #pragma warning(pop)
     }
 
     TEST_METHOD(Resources_FormatString)


### PR DESCRIPTION
## What
Disable [C26444: Don't try to declare a local variable with no name warning ](https://learn.microsoft.com/en-us/cpp/code-quality/c26444?view=msvc-170)

## Why
Prefast is flagging C26444 warning on lambda that was used in test file. However, the lambda is used as intended. Therefore disable C26444 for those cases.

## How
Declare pragma disable around the line prefast is flagging.

## Testing
Ensured unit test runs properaly