### PR TITLE
Disable c26444 for prefast and exclude test files for binskim

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -23,7 +23,8 @@ extends:
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true
-
+        analyzeTargetGlob: +:f|$(Build.SourcesDirectory)\bin\Release\*.exe;+:f|$(Build.SourcesDirectory)\bin\Release\*.dll;-:f|$(Build.SourcesDirectory)\bin\Release\*.test.*
+        
     stages:
       - stage: Build
         jobs:

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -27,6 +27,7 @@ extends:
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true
+        analyzeTargetGlob: +:f|$(Build.SourcesDirectory)\bin\Release\*.exe;+:f|$(Build.SourcesDirectory)\bin\Release\*.dll;-:f|$(Build.SourcesDirectory)\bin\Release\*.test.*
       codeql:
         compiled:
           enabled: true

--- a/test/VSIXBootstrapper.Test/CoInitializerTests.cpp
+++ b/test/VSIXBootstrapper.Test/CoInitializerTests.cpp
@@ -48,10 +48,13 @@ public:
             }
         };
 
+    #pragma warning(push)
+    #pragma warning(disable: 26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below initialization
         // CoInitializer must be in separate scope to test.
         {
             CoInitializer<TestTraits>();
         }
+    #pragma warning(pop)
 
         Assert::AreEqual<byte>(2, count);
     }


### PR DESCRIPTION
## What
This PR includes two fixes
1. Disable [C26444: Don't try to declare a local variable with no name warning ](https://learn.microsoft.com/en-us/cpp/code-quality/c26444?view=msvc-170)
2. Exclude test files from binskim

## Why
1. Prefast is flagging C26444 warning on initialization of a class in test file. However, this is being used as intended. Therefore disable C26444 for those cases. 
2. No need to binskim test files

## How
Declare pragma disable around the line prefast is flagging and add glob pattern to exclude test files for binskim

## Testing
Checked result of prefast does not contain C26444 anymore fore CoInitializer and binskim is only scanning VSIXBootstrapper.exe