### PR TITLE
Enable PME signing and allow only real sign for the CI pipeline

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
 variables:
-  SignType: Real
+  SignType: Real
 
 resources:
   repositories:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,6 +1,9 @@
 # Copyright (C) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
+variables:
+  SignType: Real
+
 resources:
   repositories:
     - repository: MicroBuildTemplate
@@ -34,6 +37,7 @@ extends:
                 signing:
                   enabled: true
                   signType: $(SignType)
+                  signWithProd: true
 
             steps:
               - template: /build/templates/build.yml@self


### PR DESCRIPTION
## What/Why
We need to enable PME signing with the new rule enforcement (Real signing with PME Enforcement - June 30th 2025).

## How
1. Enable PME signing with `signWithProd: true`
2. Only allow real signs for the CI pipeline. Will need to coordinate to remove the defined variable from the ADO pipeline.

## Testing
Verified the stages can be configured in the topic branch (which indicates no errors in the pipeline).