### PR TITLE
Fix APIScan in the compliance pipeline

### DIFF
--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -71,8 +71,10 @@ extends:
                   softwareName: 'Microsoft.VsixBootstrapper'
                   softwareVersionNum: '2' # Must match the version of ApiScan tooling
                   toolVersion: Latest
+                  azureSubscription: VSEng-APIScanSC
                 env:
-                  AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId)
+                  AzureServicesAuthConnectionString: RunAs=App;AppId=$(ApiScanClientId);TenantId=72f988bf-86f1-41af-91ab-2d7cd011db47;ServiceConnectionId=93e24264-c5e6-4681-8175-ec8a41668480;
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
               - task: PublishSecurityAnalysisLogs@3
                 displayName: Publish 'SDLAnalysis-APIScan' artifact


### PR DESCRIPTION
## What?
Update the APIScan authentication configuration in the compliance pipeline to match the current auth pattern.

## Why?
The compliance pipeline was failing at the APIScan step because the old auth format (runAs=App;AppId=...) no longer works. The managed identity credential could not be acquired, resulting in "Identity not found" errors.

## How?
Updated vsts-compliance.yml to align with the working Setup-Engine-Compliance pipeline:

   - Added azureSubscription: VSEng-APIScanSC service connection input
   - Extended AzureServicesAuthConnectionString with TenantId and ServiceConnectionId
   - Added SYSTEM_ACCESSTOKEN: $(System.AccessToken) environment variable

## Testing?
- [x] Verified the compliance pipeline passes at the APIScan step

## Screenshots (optional)
<img width="318" height="409" alt="image" src="https://github.com/user-attachments/assets/fce4f242-6352-4433-b5a3-3486d7136bf5" />